### PR TITLE
docs: fix og:image URL to include asset hash

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -27,11 +27,11 @@ search: true
 
 code_clipboard: true
 
+og_image: opengraph.webp
+
 meta:
   - name: description
     content: Find the all the information you need to implement the Gigapay API here. Simple and fast to integrate.
-  - name: og:image
-    content: "https://developer.gigapay.com/images/opengraph.webp"
 ---
 
 # API Reference

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -40,6 +40,9 @@ under the License.
         >
       <% end %>
     <% end %>
+    <% if current_page.data.og_image %>
+      <meta property="og:image" content="https://developer.gigapay.com/<%= image_path(current_page.data.og_image).sub(/^\//, '') %>">
+    <% end %>
     <title><%= current_page.data.title || "API Documentation | Gigapay" %></title>
 
     <style media="screen">


### PR DESCRIPTION
## Summary
The og:image URL added in #38 points to `images/opengraph.webp`, but Middleman's `asset_hash` extension appends a content hash to filenames at build time (e.g. `opengraph-c28f4dac.webp`), so the hardcoded URL 404s once deployed.

This PR moves the filename into a frontmatter variable and emits the meta tag from the layout using `image_path()`, so the rendered URL always matches the hashed asset.

## Test plan
- [ ] Verify `og:image` resolves to a `2xx` after deploy
- [ ] Confirm social previews render correctly