### PR TITLE
GIG-6033: Add status link to developer.gigapay.com

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,6 +9,7 @@ language_tabs: # must be one of https://github.com/rouge-ruby/rouge/wiki/List-of
 toc_footers:
   - Questions? Ask us!
   - <a href='mailto:support@gigapay.com'>support@gigapay.com</a>
+  - <a href='https://status.gigapay.net' target='_blank' rel='noopener'>System status</a>
 
 includes:
   - registrations


### PR DESCRIPTION
## Description

Adds a "System status" link to the API docs sidebar footer (`toc_footers`), pointing to the status page (https://status.gigapay.net).

Part of GIG-6028 (make the status page discoverable). developer.gigapay.com is GitHub Pages hosted, so it stays up during a Gigapay outage — exactly when integration customers go looking for incident info after API calls start failing.

- One-line addition to the Slate `toc_footers` array in `source/index.html.md`.
- Renders alongside the existing "Questions? Ask us!" / support email entries.

## Note

Links `status.gigapay.net` for now. Once GIG-6029 decides the canonical alias, swap the URL.
