### PR TITLE
GIG-6116: Document Invoice.issued and Invoice.paid webhook events

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -248,6 +248,8 @@ on the following events:
 - `Payout.canceled`
 - `Payrun.created`
 - `Payrun.paid`
+- `Invoice.issued`
+- `Invoice.paid`
 - `Registration.verified`
 
 The notifications simply contain the object that triggered the event, as represented in the API.
@@ -268,7 +270,7 @@ Each webhook notification includes the following HTTP headers:
 **Integration-Scoped Webhooks**
 <br>
 These webhooks are tied to a specific integration and require an `Integration-ID` header for all operations.
-This includes events that start with `Employee`, `Payout`, or `Payrun`.
+This includes events that start with `Employee`, `Payout`, `Payrun`, or `Invoice`.
 
 **User-Scoped Webhooks**
 <br>


### PR DESCRIPTION
## What

Documents the two new invoice webhook event types — `Invoice.issued` and `Invoice.paid` — in the public API docs. These were added to the backend (`gigapay/webhooks/`) but were not listed anywhere in the documentation.

## Changes

- Added `Invoice.issued` and `Invoice.paid` to the list of subscribable events in the Events section.
- Added `Invoice` to the integration-scoped webhook types (invoice webhooks are employer-scoped, consistent with `Employee`/`Payout`/`Payrun`).

Kept minimal and consistent with how existing events are documented: the invoice object fields are already documented in the Invoices section (`_invoices.md`), and individual events don't get their own example payload block in the Events section.